### PR TITLE
Add Windows launcher and installation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
 # ResearchDownload Native Host
 
-This repository contains a placeholder native messaging host for the
-ResearchDownload browser extension.  The Python module
-`native/researchdownload_host.py` exposes an entry point that should be
-replaced with the real implementation that communicates with the
-extension via standard input and output.
+This repository contains a fully functioning native messaging host for
+the ResearchDownload browser extension. The Python module
+`native/researchdownload_host.py` implements the Chrome native messaging
+protocol and provides a handful of diagnostic commands that are helpful
+while integrating with the accompanying browser extension.
+
+## Host commands
+
+The reference host currently supports the following commands:
+
+| Command        | Description |
+| -------------- | ----------- |
+| `ping`         | Responds with `{"type": "pong"}` and echoes the provided `payload`. |
+| `echo`         | Returns the provided `payload` unchanged. |
+| `get_version`  | Emits the host version string. |
+| `get_manifest` | Returns the manifest JSON when the host was started with `--manifest`. |
+| `shutdown`     | Acknowledges the request and terminates the host loop. |
+
+Every successful response preserves a `requestId` field when it is
+supplied in the incoming message. Errors are reported using
+`{"type": "error", "error": {"code": ..., "message": ...}}` to make
+debugging straightforward during extension development.
 
 ## Windows launcher
 
@@ -41,3 +58,6 @@ appropriate Native Messaging Hosts directory and rewrites the manifest's
   contains correctly escaped backslashes for Windows.
 * If you update `native/researchdownload_host.py`, rerun the install script to
   propagate the changes to the Windows Native Messaging Hosts directory.
+* Execute `python -m unittest discover -s tests` from the repository root to
+  run the automated tests that exercise the native messaging host command
+  handling.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# CodexTest
+# ResearchDownload Native Host
+
+This repository contains a placeholder native messaging host for the
+ResearchDownload browser extension.  The Python module
+`native/researchdownload_host.py` exposes an entry point that should be
+replaced with the real implementation that communicates with the
+extension via standard input and output.
+
+## Windows launcher
+
+A Windows-friendly launcher is provided at
+`native\dist\researchdownload_host.cmd`.  The script looks for a Python
+interpreter (`py -3`, `py.exe`, or `python`) and delegates execution to
+`native\researchdownload_host.py`.  This allows the native messaging
+manifest to reference a concrete executable path without relying on
+PowerShell.
+
+## Installing the host on Windows
+
+1. Open a PowerShell prompt.
+2. From the root of the repository, run:
+
+   ```powershell
+   ./scripts/install-host-windows.ps1
+   ```
+
+   Pass `-Browser edge` if you want to install the manifest for Microsoft Edge
+   instead of Chrome.
+
+The installer copies `native/com.yourorg.researchdownload.json` to the
+appropriate Native Messaging Hosts directory and rewrites the manifest's
+`path` field to point at the resolved
+`native\dist\researchdownload_host.cmd` launcher.
+
+## Development notes
+
+* The manifest stored in `native/com.yourorg.researchdownload.json` keeps a
+  relative path (`native\\dist\\researchdownload_host.cmd`) so that the
+  repository remains cross-platform.  The install script resolves the path to
+  an absolute location during installation, ensuring that the JSON string
+  contains correctly escaped backslashes for Windows.
+* If you update `native/researchdownload_host.py`, rerun the install script to
+  propagate the changes to the Windows Native Messaging Hosts directory.

--- a/native/com.yourorg.researchdownload.json
+++ b/native/com.yourorg.researchdownload.json
@@ -1,0 +1,10 @@
+{
+  "name": "com.yourorg.researchdownload",
+  "description": "ResearchDownload native messaging host",
+  "path": "native\\dist\\researchdownload_host.cmd",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://exampleid1234567890abcdef/",
+    "chrome-extension://anotherexampleid0987654321/"
+  ]
+}

--- a/native/dist/researchdownload_host.cmd
+++ b/native/dist/researchdownload_host.cmd
@@ -1,0 +1,34 @@
+@echo off
+setlocal
+set "SCRIPT_DIR=%~dp0"
+set "HOST_SCRIPT=%SCRIPT_DIR%..\researchdownload_host.py"
+
+if exist "%SYSTEMROOT%\py.exe" (
+    set "PY_CMD=%SYSTEMROOT%\py.exe -3"
+) else (
+    where py >nul 2>nul
+    if %errorlevel% equ 0 (
+        set "PY_CMD=py -3"
+    ) else (
+        where python >nul 2>nul
+        if %errorlevel% equ 0 (
+            for /f "delims=" %%I in ('where python') do (
+                set "PY_CMD=%%I"
+                goto :run
+            )
+        ) else (
+            echo Could not find a Python interpreter on PATH. >&2
+            exit /b 9009
+        )
+    )
+)
+
+:run
+if not exist "%HOST_SCRIPT%" (
+    echo Unable to locate host script at %HOST_SCRIPT%. >&2
+    exit /b 2
+)
+
+call %PY_CMD% "%HOST_SCRIPT%" %*
+set "EXITCODE=%ERRORLEVEL%"
+endlocal & exit /b %EXITCODE%

--- a/native/researchdownload_host.py
+++ b/native/researchdownload_host.py
@@ -1,0 +1,71 @@
+"""Entry point for the ResearchDownload native messaging host.
+
+This module is a placeholder implementation that demonstrates how the
+native messaging host could be launched.  The real project should
+replace the ``main`` function with the actual host logic that
+communicates with the browser extension over stdin/stdout.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments for the host launcher."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Launch the ResearchDownload native messaging host. "
+            "This placeholder implementation simply echoes JSON input."
+        )
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help="Optional path to a manifest file to display when starting.",
+    )
+    return parser.parse_args(argv)
+
+
+def load_manifest(manifest_path: Path | None) -> dict[str, Any] | None:
+    """Load a manifest if it exists.
+
+    Parameters
+    ----------
+    manifest_path:
+        The manifest file path that should be displayed.
+    """
+    if manifest_path is None:
+        return None
+    if not manifest_path.exists():
+        print(f"Manifest not found: {manifest_path}", file=sys.stderr)
+        return None
+    try:
+        manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"Failed to decode manifest JSON: {exc}", file=sys.stderr)
+        return None
+    return manifest_data
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    manifest = load_manifest(args.manifest)
+    if manifest:
+        manifest_path = args.manifest if args.manifest else "(provided manifest)"
+        print(f"Loaded manifest from {manifest_path}")
+        print(json.dumps(manifest, indent=2))
+
+    print(
+        "ResearchDownload native host placeholder running. "
+        "Provide implementation in native/researchdownload_host.py."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/native/researchdownload_host.py
+++ b/native/researchdownload_host.py
@@ -1,70 +1,336 @@
 """Entry point for the ResearchDownload native messaging host.
 
-This module is a placeholder implementation that demonstrates how the
-native messaging host could be launched.  The real project should
-replace the ``main`` function with the actual host logic that
-communicates with the browser extension over stdin/stdout.
+The host follows the Chrome native messaging protocol. Messages are
+received from ``stdin`` as a four-byte little-endian length prefix
+followed by a UTF-8 encoded JSON payload. Responses are written to
+``stdout`` using the same framing.
+
+The implementation is intentionally simple but fully functional. It
+supports a handful of diagnostic commands that make it easy to validate
+the browser integration without needing the final business logic in
+place. The commands that are currently recognised are:
+
+``ping``
+    Responds with ``{"type": "pong"}`` and echoes any ``payload`` field.
+``echo``
+    Returns the supplied ``payload`` verbatim.
+``get_version``
+    Provides the host version as ``{"type": "version", "version": ...}``.
+``get_manifest``
+    Emits the manifest JSON that the host was launched with (when
+    ``--manifest`` is provided).
+``shutdown``
+    Replies with ``{"type": "shutdown", "status": "ok"}`` and stops the
+    host loop.
+
+Additional commands can be layered on top of :class:`NativeMessagingHost`
+by extending :meth:`NativeMessagingHost._handle_message`.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import logging
+import struct
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO, Tuple
+
+HOST_VERSION = "0.1.0"
+
+
+RequestId = str | int | None
+
+
+class NativeMessagingProtocolError(RuntimeError):
+    """Raised when the input stream does not follow the messaging protocol."""
+
+
+class NativeMessagingHost:
+    """Minimal native messaging host implementation.
+
+    Parameters
+    ----------
+    input_stream:
+        Binary stream to read messages from (typically ``sys.stdin.buffer``).
+    output_stream:
+        Binary stream to write messages to (typically ``sys.stdout.buffer``).
+    manifest:
+        Optional manifest data loaded from JSON. Required to service the
+        ``get_manifest`` command.
+    max_message_bytes:
+        Upper bound for any single message body. Messages that exceed the
+        limit raise :class:`NativeMessagingProtocolError`.
+    """
+
+    def __init__(
+        self,
+        input_stream: BinaryIO,
+        output_stream: BinaryIO,
+        manifest: dict[str, Any] | None = None,
+        *,
+        max_message_bytes: int = 2_097_152,
+    ) -> None:
+        self._input = input_stream
+        self._output = output_stream
+        self._manifest = manifest
+        self._max_message_bytes = max_message_bytes
+
+    def run(self) -> int:
+        """Process messages until EOF or a ``shutdown`` command is received."""
+
+        while True:
+            try:
+                raw_payload = self._read_message_bytes()
+            except NativeMessagingProtocolError as exc:
+                logging.error("Protocol error: %s", exc)
+                self._send_error("protocol_error", str(exc))
+                return 1
+
+            if raw_payload is None:
+                logging.debug("EOF reached; shutting down host loop")
+                return 0
+
+            try:
+                message = json.loads(raw_payload.decode("utf-8"))
+            except json.JSONDecodeError as exc:
+                logging.warning("Received invalid JSON payload: %s", exc)
+                self._send_error(
+                    "invalid_json",
+                    f"Failed to decode JSON payload: {exc}",
+                )
+                continue
+
+            request_id = message.get("requestId")
+            if not isinstance(request_id, (str, int)):
+                request_id = None
+
+            try:
+                response, should_exit = self._handle_message(message, request_id)
+            except Exception as exc:  # pragma: no cover - defensive guard
+                logging.exception("Unhandled error while processing message")
+                self._send_error(
+                    "internal_error",
+                    "Unhandled error while processing message.",
+                    request_id=request_id,
+                )
+                continue
+
+            if response is not None:
+                self._send_message(response, request_id=request_id)
+
+            if should_exit:
+                logging.info("Shutdown command processed; exiting host loop")
+                return 0
+
+    def _read_message_bytes(self) -> bytes | None:
+        """Read a single message from ``stdin``.
+
+        Returns ``None`` when EOF is reached before the length prefix. Raises
+        :class:`NativeMessagingProtocolError` if the stream terminates before
+        the declared message length is satisfied.
+        """
+
+        raw_length = self._input.read(4)
+        if raw_length == b"":
+            return None
+        if len(raw_length) < 4:
+            raise NativeMessagingProtocolError(
+                "Unexpected EOF while reading message length prefix"
+            )
+
+        message_length = struct.unpack("<I", raw_length)[0]
+        if message_length > self._max_message_bytes:
+            raise NativeMessagingProtocolError(
+                f"Message length {message_length} exceeds maximum of "
+                f"{self._max_message_bytes} bytes"
+            )
+
+        payload = self._read_exact(message_length)
+        return payload
+
+    def _read_exact(self, size: int) -> bytes:
+        """Read exactly ``size`` bytes from the input stream."""
+
+        remaining = size
+        chunks = bytearray()
+        while remaining > 0:
+            chunk = self._input.read(remaining)
+            if chunk == b"":
+                raise NativeMessagingProtocolError(
+                    "Unexpected EOF while reading message body"
+                )
+            chunks.extend(chunk)
+            remaining -= len(chunk)
+        return bytes(chunks)
+
+    def _handle_message(
+        self, message: Any, request_id: RequestId
+    ) -> Tuple[dict[str, Any] | None, bool]:
+        """Implement the ResearchDownload host command set."""
+
+        if not isinstance(message, dict):
+            self._send_error(
+                "invalid_payload",
+                "Expected JSON object payload.",
+                request_id=request_id,
+            )
+            return None, False
+
+        command = message.get("command")
+        if not isinstance(command, str):
+            self._send_error(
+                "missing_command",
+                "Message must include a string 'command' field.",
+                request_id=request_id,
+            )
+            return None, False
+
+        logging.debug("Processing command '%s'", command)
+
+        if command == "ping":
+            return {
+                "type": "pong",
+                "payload": message.get("payload"),
+            }, False
+
+        if command == "echo":
+            return {
+                "type": "echo",
+                "payload": message.get("payload"),
+            }, False
+
+        if command == "get_version":
+            return {"type": "version", "version": HOST_VERSION}, False
+
+        if command == "get_manifest":
+            if self._manifest is None:
+                self._send_error(
+                    "manifest_unavailable",
+                    "Host was started without a manifest path.",
+                    request_id=request_id,
+                )
+                return None, False
+            return {"type": "manifest", "manifest": self._manifest}, False
+
+        if command == "shutdown":
+            return {"type": "shutdown", "status": "ok"}, True
+
+        self._send_error(
+            "unknown_command",
+            f"Unsupported command: {command}",
+            request_id=request_id,
+        )
+        return None, False
+
+    def _send_message(self, payload: dict[str, Any], request_id: RequestId) -> None:
+        """Encode *payload* and write it to the output stream."""
+
+        message = dict(payload)
+        if request_id is not None:
+            message.setdefault("requestId", request_id)
+
+        encoded = json.dumps(message, ensure_ascii=False).encode("utf-8")
+        header = struct.pack("<I", len(encoded))
+        self._output.write(header)
+        self._output.write(encoded)
+        self._output.flush()
+
+    def _send_error(
+        self,
+        code: str,
+        message: str,
+        *,
+        request_id: RequestId = None,
+    ) -> None:
+        """Send a structured error response."""
+
+        error_body = {
+            "type": "error",
+            "error": {
+                "code": code,
+                "message": message,
+            },
+        }
+        self._send_message(error_body, request_id=request_id)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command line arguments for the host launcher."""
+
     parser = argparse.ArgumentParser(
-        description=(
-            "Launch the ResearchDownload native messaging host. "
-            "This placeholder implementation simply echoes JSON input."
-        )
+        description="Run the ResearchDownload native messaging host",
     )
     parser.add_argument(
         "--manifest",
         type=Path,
         default=None,
-        help="Optional path to a manifest file to display when starting.",
+        help=(
+            "Optional path to the native messaging manifest. Required when "
+            "using the 'get_manifest' command."
+        ),
+    )
+    parser.add_argument(
+        "--log-level",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        default="WARNING",
+        help="Adjust the logging verbosity emitted to stderr.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=HOST_VERSION,
     )
     return parser.parse_args(argv)
 
 
 def load_manifest(manifest_path: Path | None) -> dict[str, Any] | None:
-    """Load a manifest if it exists.
+    """Load manifest JSON from ``manifest_path`` when provided."""
 
-    Parameters
-    ----------
-    manifest_path:
-        The manifest file path that should be displayed.
-    """
     if manifest_path is None:
         return None
     if not manifest_path.exists():
-        print(f"Manifest not found: {manifest_path}", file=sys.stderr)
-        return None
-    try:
-        manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        print(f"Failed to decode manifest JSON: {exc}", file=sys.stderr)
-        return None
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+    manifest_data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(manifest_data, dict):
+        raise ValueError("Manifest JSON must be an object")
     return manifest_data
+
+
+def configure_logging(level: str) -> None:
+    numeric_level = getattr(logging, level.upper(), logging.WARNING)
+    logging.basicConfig(
+        level=numeric_level,
+        format="%(asctime)s %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
-    manifest = load_manifest(args.manifest)
-    if manifest:
-        manifest_path = args.manifest if args.manifest else "(provided manifest)"
-        print(f"Loaded manifest from {manifest_path}")
-        print(json.dumps(manifest, indent=2))
+    configure_logging(args.log_level)
 
-    print(
-        "ResearchDownload native host placeholder running. "
-        "Provide implementation in native/researchdownload_host.py."
+    manifest: dict[str, Any] | None = None
+    try:
+        manifest = load_manifest(args.manifest)
+    except FileNotFoundError as exc:
+        logging.error("%s", exc)
+        return 2
+    except ValueError as exc:
+        logging.error("%s", exc)
+        return 3
+
+    host = NativeMessagingHost(
+        sys.stdin.buffer,
+        sys.stdout.buffer,
+        manifest=manifest,
     )
-    return 0
+
+    try:
+        return host.run()
+    except KeyboardInterrupt:
+        logging.info("Keyboard interrupt received; shutting down host")
+        return 0
 
 
 if __name__ == "__main__":

--- a/scripts/install-host-windows.ps1
+++ b/scripts/install-host-windows.ps1
@@ -1,0 +1,38 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("chrome", "edge")]
+    [string]$Browser = "chrome"
+)
+
+$repoRoot = Resolve-Path (Join-Path $PSScriptRoot "..")
+$manifestTemplatePath = Join-Path $repoRoot "native\com.yourorg.researchdownload.json"
+$launcherPath = Join-Path $repoRoot "native\dist\researchdownload_host.cmd"
+
+if (-not (Test-Path -Path $manifestTemplatePath)) {
+    throw "Unable to find manifest template at $manifestTemplatePath"
+}
+
+if (-not (Test-Path -Path $launcherPath)) {
+    throw "Unable to find launcher at $launcherPath. Ensure the .cmd shim exists."
+}
+
+$resolvedLauncherPath = (Resolve-Path -Path $launcherPath).Path
+$manifestTemplate = Get-Content -Path $manifestTemplatePath -Raw | ConvertFrom-Json
+$manifestTemplate.path = $resolvedLauncherPath
+
+switch ($Browser) {
+    "chrome" {
+        $targetDir = Join-Path $env:LOCALAPPDATA "Google\Chrome\User Data\NativeMessagingHosts"
+    }
+    "edge" {
+        $targetDir = Join-Path $env:LOCALAPPDATA "Microsoft\Edge\User Data\NativeMessagingHosts"
+    }
+}
+
+New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+$targetManifestPath = Join-Path $targetDir "com.yourorg.researchdownload.json"
+$manifestJson = $manifestTemplate | ConvertTo-Json -Depth 5
+$manifestJson | Set-Content -Path $targetManifestPath -Encoding UTF8
+
+Write-Host "Installed ResearchDownload host manifest to $targetManifestPath"
+Write-Host "Host launcher path: $resolvedLauncherPath"

--- a/tests/test_researchdownload_host.py
+++ b/tests/test_researchdownload_host.py
@@ -1,0 +1,125 @@
+"""Unit tests for the ResearchDownload native messaging host."""
+from __future__ import annotations
+
+import io
+import json
+import struct
+import unittest
+from typing import Any, Iterable, Tuple
+
+from native.researchdownload_host import NativeMessagingHost
+
+
+def _encode_messages(messages: Iterable[dict[str, Any]]) -> bytes:
+    buffer = bytearray()
+    for message in messages:
+        payload = json.dumps(message).encode("utf-8")
+        buffer.extend(struct.pack("<I", len(payload)))
+        buffer.extend(payload)
+    return bytes(buffer)
+
+
+def _decode_messages(payload: bytes) -> list[dict[str, Any]]:
+    stream = io.BytesIO(payload)
+    decoded: list[dict[str, Any]] = []
+    while True:
+        header = stream.read(4)
+        if header == b"":
+            break
+        length = struct.unpack("<I", header)[0]
+        body = stream.read(length)
+        decoded.append(json.loads(body.decode("utf-8")))
+    return decoded
+
+
+def _run_host(
+    messages: Iterable[dict[str, Any]],
+    *,
+    manifest: dict[str, Any] | None = None,
+) -> Tuple[int, list[dict[str, Any]]]:
+    input_bytes = _encode_messages(messages)
+    input_stream = io.BytesIO(input_bytes)
+    output_stream = io.BytesIO()
+
+    host = NativeMessagingHost(
+        input_stream,
+        output_stream,
+        manifest=manifest,
+    )
+    exit_code = host.run()
+
+    output_stream.seek(0)
+    responses = _decode_messages(output_stream.read())
+    return exit_code, responses
+
+
+class NativeMessagingHostTests(unittest.TestCase):
+    def test_ping_round_trip(self) -> None:
+        exit_code, responses = _run_host([
+            {"command": "ping", "requestId": "abc123", "payload": {"value": 42}},
+        ])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(
+            responses[0],
+            {
+                "type": "pong",
+                "payload": {"value": 42},
+                "requestId": "abc123",
+            },
+        )
+
+    def test_unknown_command_returns_error(self) -> None:
+        exit_code, responses = _run_host([
+            {"command": "does_not_exist", "requestId": 99},
+        ])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(len(responses), 1)
+        self.assertEqual(
+            responses[0],
+            {
+                "type": "error",
+                "error": {
+                    "code": "unknown_command",
+                    "message": "Unsupported command: does_not_exist",
+                },
+                "requestId": 99,
+            },
+        )
+
+    def test_get_manifest_requires_manifest(self) -> None:
+        manifest = {"name": "com.yourorg.researchdownload"}
+        exit_code, responses = _run_host([
+            {"command": "get_manifest", "requestId": "m1"},
+        ], manifest=manifest)
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            responses[0],
+            {
+                "type": "manifest",
+                "manifest": manifest,
+                "requestId": "m1",
+            },
+        )
+
+    def test_shutdown_command_exits_loop(self) -> None:
+        exit_code, responses = _run_host([
+            {"command": "shutdown", "requestId": "done"},
+        ])
+
+        self.assertEqual(exit_code, 0)
+        self.assertEqual(
+            responses[0],
+            {
+                "type": "shutdown",
+                "status": "ok",
+                "requestId": "done",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a placeholder native messaging host entry point in Python
- provide a Windows-friendly CMD launcher and update the native messaging manifest
- document installation steps and ship a PowerShell helper for installing the manifest

## Testing
- python -m compileall native/researchdownload_host.py

------
https://chatgpt.com/codex/tasks/task_e_68ccebed8b60832185a012c1711f2b55